### PR TITLE
support nullable property [waiting for review]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,21 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode8.2
 script:
-    - xctool -sdk iphonesimulator -project Polymorph.xcodeproj -scheme "PolymorphTests iOS" test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
-    - xctool -sdk macosx -project Polymorph.xcodeproj -scheme "PolymorphTests OSX" test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+script:
+    - |
+      xcodebuild test \
+      -project Polymorph.xcodeproj \
+      -scheme "PolymorphTests iOS" \
+      -sdk iphonesimulator \
+      -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.1' \
+      ONLY_ACTIVE_ARCH=NO  GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+
+    - |
+      xcodebuild test \
+      -project Polymorph.xcodeproj \
+      -scheme "PolymorphTests OSX" \
+      -sdk macosx \
+      -destination 'platform=macOS,arch=x86_64' \
+      ONLY_ACTIVE_ARCH=NO  GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/Polymorph.xcodeproj/xcshareddata/xcschemes/Polymorph.xcscheme
+++ b/Polymorph.xcodeproj/xcshareddata/xcschemes/Polymorph.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
@@ -50,13 +50,6 @@
             ReferencedContainer = "container:Polymorph.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "TEST"
-            value = "1"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Polymorph.xcodeproj/xcshareddata/xcschemes/Polymorph.xcscheme
+++ b/Polymorph.xcodeproj/xcshareddata/xcschemes/Polymorph.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
@@ -49,6 +50,13 @@
             ReferencedContainer = "container:Polymorph.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TEST"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -56,6 +64,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests OSX.xcscheme
+++ b/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests OSX.xcscheme
@@ -7,9 +7,10 @@
       buildImplicitDependencies = "YES">
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -27,9 +28,10 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests iOS.xcscheme
+++ b/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests iOS.xcscheme
@@ -7,7 +7,7 @@
       buildImplicitDependencies = "YES">
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
@@ -28,7 +28,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
@@ -38,13 +38,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "TEST"
-            value = "1"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests iOS.xcscheme
+++ b/Polymorph.xcodeproj/xcshareddata/xcschemes/PolymorphTests iOS.xcscheme
@@ -10,6 +10,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -30,12 +31,20 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TEST"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Polymorph/Polymorph.h
+++ b/Polymorph/Polymorph.h
@@ -82,13 +82,13 @@
  *      @plm_dynamic(date, GMTDateTransformerName)
  *
  *  Note:
- *  Only plm_nullable_dynamic(...) and plm_nullable_dynamic_keypath(...) may return nil, the others will always
- *  return a nonnull value. So it is recommended to use plm_nullable_dynamic_xxx for `nullable` property and
+ *  Only plm_dynamic_nullable(...) and plm_dynamic_nullable_keypath(...) may return nil, the others will always
+ *  return a nonnull value. So it is recommended to use plm_dynamic_nullable_xxx for `nullable` property and
  *  plm_dynamic_xxx for `nonnull` property.
  */
 #define plm_dynamic(...)  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), {_plm_dynamic_attr(__VA_ARGS__);})
 
-#define plm_nullable_dynamic(...) \
+#define plm_dynamic_nullable(...) \
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
     NSDictionary *attrs = (NSDictionary *)_plm_dynamic_attr(__VA_ARGS__); \
     if (!attrs) { \
@@ -113,7 +113,7 @@
     attrs; \
   })
 
-#define plm_nullable_dynamic_keypath(...) \
+#define plm_dynamic_nullable_keypath(...) \
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
     NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
     attrs[_PolymorphAttributeKeypath] = @YES; \

--- a/Polymorph/Polymorph.h
+++ b/Polymorph/Polymorph.h
@@ -81,9 +81,23 @@
  *
  *      @plm_dynamic(date, GMTDateTransformerName)
  *
- *
+ *  Note:
+ *  Only plm_nullable_dynamic(...) and plm_nullable_dynamic_keypath(...) may return nil, the others will always
+ *  return a nonnull value. So it is recommended to use plm_nullable_dynamic_xxx for `nullable` property and
+ *  plm_dynamic_xxx for `nonnull` property.
  */
 #define plm_dynamic(...)  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), {_plm_dynamic_attr(__VA_ARGS__);})
+
+#define plm_nullable_dynamic(...) \
+  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
+    NSDictionary *attrs = (NSDictionary *)_plm_dynamic_attr(__VA_ARGS__); \
+    if (!attrs) { \
+      attrs = [NSDictionary dictionary]; \
+    } \
+    NSMutableDictionary *mutAttrs = [attrs mutableCopy]; \
+    mutAttrs[_PolymorphAttributeNullable] = @YES; \
+    mutAttrs; \
+  })
 
 /**
  *  Same arguments as `plm_dynamic`, except the field name specified by second
@@ -96,6 +110,14 @@
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
     NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
     attrs[_PolymorphAttributeKeypath] = @YES; \
+    attrs; \
+  })
+
+#define plm_nullable_dynamic_keypath(...) \
+  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
+    NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
+    attrs[_PolymorphAttributeKeypath] = @YES; \
+    attrs[_PolymorphAttributeNullable] = @YES; \
     attrs; \
   })
 
@@ -142,6 +164,7 @@
 #define _PolymorphAttributeJSONField     @"fd"
 #define _PolymorphAttributeTransformer   @"tf"
 #define _PolymorphAttributeKeypath       @"kp"
+#define _PolymorphAttributeNullable      @"nb"
 
 #define _plm_dynamic_attr(...) metamacro_concat(_plm_dynamic_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
 

--- a/Polymorph/Polymorph.h
+++ b/Polymorph/Polymorph.h
@@ -82,20 +82,34 @@
  *      @plm_dynamic(date, GMTDateTransformerName)
  *
  *  Note:
- *  Only plm_dynamic_nullable(...) and plm_dynamic_nullable_keypath(...) may return nil, the others will always
- *  return a nonnull value. So it is recommended to use plm_dynamic_nullable_xxx for `nullable` property and
- *  plm_dynamic_xxx for `nonnull` property.
+ *  1. Only plm_dynamic_nullable(...) and plm_dynamic_nullable_keypath(...) may return nil, the others will always
+ *     return a nonnull value;
+ *  2. plm_dynamic_nonnull(...) and plm_dynamic_nonnull_keypath(...) need to set an object value at the last argument as
+       the default value when it is nil;
+ *  3. plm_dynamic(...), plm_dynamic_keypath(...) and plm_dynamic_multi(...) will return a default value when the object is nil;
+ *  4. It is recommended to use plm_dynamic_nullable_xxx for `nullable` property and plm_dynamic_nonnull_xxx for `nonnull` property.
  */
 #define plm_dynamic(...)  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), {_plm_dynamic_attr(__VA_ARGS__);})
 
 #define plm_dynamic_nullable(...) \
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
-    NSDictionary *attrs = (NSDictionary *)_plm_dynamic_attr(__VA_ARGS__); \
+  NSDictionary *attrs = (NSDictionary *)_plm_dynamic_attr(__VA_ARGS__); \
+  if (!attrs) { \
+    attrs = [NSDictionary dictionary]; \
+  } \
+  NSMutableDictionary *mutAttrs = [attrs mutableCopy]; \
+  mutAttrs[_PolymorphAttributeNullable] = @YES; \
+  mutAttrs; \
+  })
+
+#define plm_dynamic_nonnull(...) \
+  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
+    NSDictionary *attrs = (NSDictionary *)_plm_dynamic_nonnull_attr(__VA_ARGS__); \
     if (!attrs) { \
       attrs = [NSDictionary dictionary]; \
     } \
     NSMutableDictionary *mutAttrs = [attrs mutableCopy]; \
-    mutAttrs[_PolymorphAttributeNullable] = @YES; \
+    mutAttrs[_PolymorphAttributeNullable] = @NO; \
     mutAttrs; \
   })
 
@@ -115,9 +129,17 @@
 
 #define plm_dynamic_nullable_keypath(...) \
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
-    NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
+  NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
+  attrs[_PolymorphAttributeKeypath] = @YES; \
+  attrs[_PolymorphAttributeNullable] = @YES; \
+  attrs; \
+  })
+
+#define plm_dynamic_nonnull_keypath(...) \
+  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
+    NSMutableDictionary *attrs = [_plm_dynamic_nonnull_attr(__VA_ARGS__) mutableCopy]; \
     attrs[_PolymorphAttributeKeypath] = @YES; \
-    attrs[_PolymorphAttributeNullable] = @YES; \
+    attrs[_PolymorphAttributeNullable] = @NO; \
     attrs; \
   })
 
@@ -165,8 +187,10 @@
 #define _PolymorphAttributeTransformer   @"tf"
 #define _PolymorphAttributeKeypath       @"kp"
 #define _PolymorphAttributeNullable      @"nb"
+#define _PolymorphAttributeDefaultValue  @"dv"
 
 #define _plm_dynamic_attr(...) metamacro_concat(_plm_dynamic_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
+#define _plm_dynamic_nonnull_attr(...) metamacro_concat(_plm_dynamic_nonnull_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
 
 #define _plm_dynamic_attr1(...) nil
 #define _plm_dynamic_attr2(...) @{ \
@@ -181,3 +205,27 @@
     _PolymorphAttributeTransformer: metamacro_at(2, __VA_ARGS__), \
     _PolymorphAttributeKeypath:     metamacro_at(3, __VA_ARGS__), \
   }
+
+#pragma mark - plm_dynamic_nonnull()
+
+#define _plm_dynamic_nonnull_attr2(...) @{ \
+  _PolymorphAttributeDefaultValue: metamacro_at(1, __VA_ARGS__) \
+}
+#define _plm_dynamic_nonnull_attr3(...) @{ \
+  _PolymorphAttributeJSONField:   metamacro_at(1, __VA_ARGS__), \
+  _PolymorphAttributeDefaultValue: metamacro_at(2, __VA_ARGS__) \
+}
+#define _plm_dynamic_nonnull_attr4(...) @{ \
+  _PolymorphAttributeJSONField:   metamacro_at(1, __VA_ARGS__), \
+  _PolymorphAttributeTransformer: metamacro_at(2, __VA_ARGS__), \
+  _PolymorphAttributeDefaultValue: metamacro_at(3, __VA_ARGS__) \
+}
+#define _plm_dynamic_nonnull_attr5(...) @{ \
+  _PolymorphAttributeJSONField:   metamacro_at(1, __VA_ARGS__), \
+  _PolymorphAttributeTransformer: metamacro_at(2, __VA_ARGS__), \
+  _PolymorphAttributeKeypath:     metamacro_at(3, __VA_ARGS__), \
+  _PolymorphAttributeDefaultValue: metamacro_at(4, __VA_ARGS__) \
+}
+
+
+

--- a/Polymorph/Polymorph.m
+++ b/Polymorph/Polymorph.m
@@ -27,6 +27,10 @@
     VAR = nil; \
   }
 
+#ifdef DEBUG
+static BOOL isRunningTest();
+#endif
+
 /**
  *  Parse property name from getter method name.
  *
@@ -173,6 +177,13 @@ static id getter_impl(NSObject<PLMRawDataProvider> *self,
   }
 
   if (!value && !isNullable) {
+
+#ifdef DEBUG
+    if (!isRunningTest()) {
+      NSCAssert(NO, @"nonnull property should not be nill");
+    }
+#endif
+
     if (targetClass == [NSNumber class]) {
       value = [NSNumber numberWithInt:0];
     }
@@ -375,6 +386,12 @@ static void check_accessor(Class class)
   if (classes) {
     free(classes);
   }
+}
+
+static BOOL isRunningTest()
+{
+  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
+  return [environment[@"TEST"] boolValue];
 }
 
 #endif /* defined DEBUG */

--- a/Polymorph/Polymorph.m
+++ b/Polymorph/Polymorph.m
@@ -27,10 +27,6 @@
     VAR = nil; \
   }
 
-#ifdef DEBUG
-static BOOL isRunningTest();
-#endif
-
 /**
  *  Parse property name from getter method name.
  *
@@ -180,13 +176,9 @@ static id getter_impl(NSObject<PLMRawDataProvider> *self,
   if (!value && !isNullable) {
     value = defaultValue;
 
-#ifdef DEBUG
-    if (!isRunningTest() && !value) {
-      NSCAssert(NO, @"nonnull property should not be nill");
-    }
-#endif
-
     if (!value) {
+      NSCAssert(NO, @"nonnull property should not be nil.");
+
       if (targetClass == [NSNumber class]) {
         value = [NSNumber numberWithInt:0];
       }
@@ -393,12 +385,6 @@ static void check_accessor(Class class)
   if (classes) {
     free(classes);
   }
-}
-
-static BOOL isRunningTest()
-{
-  NSDictionary *environment = [[NSProcessInfo processInfo] environment];
-  return [environment[@"TEST"] boolValue];
 }
 
 #endif /* defined DEBUG */

--- a/Polymorph/Polymorph.m
+++ b/Polymorph/Polymorph.m
@@ -178,10 +178,7 @@ static id getter_impl(NSObject<PLMRawDataProvider> *self,
   }
 
   if (!value && !isNullable) {
-
-    if (defaultValue) {
-      value = defaultValue;
-    }
+    value = defaultValue;
 
 #ifdef DEBUG
     if (!isRunningTest() && !value) {
@@ -197,6 +194,8 @@ static id getter_impl(NSObject<PLMRawDataProvider> *self,
         value = [[targetClass alloc] init];
       }
     }
+
+    NSCAssert(value != nil, @"`value` should not be nil.");
   }
 
   safety_type_check(value, targetClass);

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -87,6 +87,13 @@ metamacro_foreach(decl_type_iter,, PRIMITIVE_TYPES)
 
 @property (nonatomic, assign) BOOL HTTP;
 
+@property (nonatomic, strong, nullable) NSNumber *nilNumber;
+@property (nonatomic, assign) NSInteger nonnullInt;
+@property (nonatomic, strong) NSNumber *nonnullNumber;
+@property (nonatomic, nullable, copy) NSString *nilString;
+@property (nonatomic, nullable, copy) NSString *nilString2;
+@property (nonatomic, nonnull, copy) NSString *nonnullString;
+
 @end
 
 NSValueTransformer *EmptyObjectTransformer()
@@ -121,6 +128,14 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 
 @plm_dynamic(emptyObject, @"empty", EmptyObjectTransformer())
 
+@plm_nullable_dynamic(nilString)
+@plm_nullable_dynamic(nilString2, @"nil_string2")
+
+@plm_dynamic(nonnullString, @"nonnull_string")
+@plm_dynamic(nonnullInt)
+@plm_dynamic(nonnullNumber)
+@plm_nullable_dynamic(nilNumber)
+
 @end
 
 @interface PolymorphTests : XCTestCase
@@ -154,6 +169,17 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
   XCTAssertEqual(object.doubleIt, 200);
   object.doubleIt = 500;
   XCTAssertEqual(object.doubleIt, 500);
+}
+
+- (void)testNullable
+{
+  _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{}];
+  XCTAssertNil(object.nilString);
+  XCTAssertNil(object.nilString2);
+  XCTAssertNotNil(object.nonnullString);
+  XCTAssert(object.nonnullInt == 0);
+  XCTAssertNotNil(object.nonnullNumber);
+  XCTAssertNil(object.nilNumber);
 }
 
 - (void)testObjectTypes
@@ -270,7 +296,7 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 {
   _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{@"is_voted": [NSNull null], @"url": [NSNull null]}];
   XCTAssertEqual(object.isVoted, NO);
-  XCTAssertNil(object.url);
+  XCTAssertNotNil(object.url);
 }
 
 - (void)testKeypath

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -87,12 +87,17 @@ metamacro_foreach(decl_type_iter,, PRIMITIVE_TYPES)
 
 @property (nonatomic, assign) BOOL HTTP;
 
-@property (nonatomic, strong, nullable) NSNumber *nilNumber;
-@property (nonatomic, assign) NSInteger nonnullInt;
+@property (nonatomic, strong) NSNumber *normalNumbler;
 @property (nonatomic, strong) NSNumber *nonnullNumber;
-@property (nonatomic, nullable, copy) NSString *nilString;
-@property (nonatomic, nullable, copy) NSString *nilString2;
+@property (nonatomic, strong, nullable) NSNumber *nilNumber;
+@property (nonatomic, strong, nonnull, readonly) NSNumber *keypathNonnullNumber;
+@property (nonatomic, strong, nullable, readonly) NSNumber *keypathNilNumber;
+
+@property (nonatomic, copy) NSString *normalString;
 @property (nonatomic, nonnull, copy) NSString *nonnullString;
+@property (nonatomic, nullable, copy) NSString *nilString;
+@property (nonatomic, copy, nonnull, readonly) NSString *keypathNonnullString;
+@property (nonatomic, copy, nullable, readonly) NSString *keypathNilString;
 
 @end
 
@@ -128,13 +133,17 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 
 @plm_dynamic(emptyObject, @"empty", EmptyObjectTransformer())
 
-@plm_dynamic_nullable(nilString)
-@plm_dynamic_nullable(nilString2, @"nil_string2")
+@plm_dynamic(normalNumbler)
+@plm_dynamic_nonnull(nonnullNumber, @"nonnull_number", [NSNumber numberWithInteger:20])
+@plm_dynamic_nullable(nilNumber, @"nil_number")
+@plm_dynamic_nonnull_keypath(keypathNonnullNumber, @"xxx", [NSNumber numberWithInteger:20])
+@plm_dynamic_nullable_keypath(keypathNilNumber, @"xxx")
 
-@plm_dynamic(nonnullString, @"nonnull_string")
-@plm_dynamic(nonnullInt)
-@plm_dynamic(nonnullNumber)
-@plm_dynamic_nullable(nilNumber)
+@plm_dynamic(normalString)
+@plm_dynamic_nonnull(nonnullString, @"default_nonnull_string")
+@plm_dynamic_nullable(nilString)
+@plm_dynamic_nonnull_keypath(keypathNonnullString, @"yyy", @"keypath_nonnull_string")
+@plm_dynamic_nullable_keypath(keypathNilString, @"yyy")
 
 @end
 
@@ -171,15 +180,20 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
   XCTAssertEqual(object.doubleIt, 500);
 }
 
-- (void)testNullable
+- (void)testNullability
 {
   _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{}];
-  XCTAssertNil(object.nilString);
-  XCTAssertNil(object.nilString2);
-  XCTAssertNotNil(object.nonnullString);
-  XCTAssert(object.nonnullInt == 0);
-  XCTAssertNotNil(object.nonnullNumber);
+  XCTAssertNotNil(object.normalNumbler);
+  XCTAssertEqual(object.nonnullNumber, [NSNumber numberWithInteger:20]);
   XCTAssertNil(object.nilNumber);
+  XCTAssertEqual(object.keypathNonnullNumber, [NSNumber numberWithInteger:20]);
+  XCTAssertNil(object.keypathNilNumber);
+
+  XCTAssertNotNil(object.normalString);
+  XCTAssertEqual(object.nonnullString, @"default_nonnull_string");
+  XCTAssertNil(object.nilString);
+  XCTAssertEqual(object.keypathNonnullString, @"keypath_nonnull_string");
+  XCTAssertNil(object.keypathNilString);
 }
 
 - (void)testObjectTypes

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -322,8 +322,15 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 - (void)testInvalidData
 {
   _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{@"is_voted": @"yes", @"str": @1000}];
+
+  // UT 使用的是 Release 配置，Release 配置关掉了 Assertion，所以 DEBUG 下不会 Throws
+#ifdef DEBUG
   XCTAssertThrows(object.isVoted);
   XCTAssertThrows(object.str);
+#else
+  XCTAssertFalse(object.isVoted);
+  XCTAssertNil(object.str);
+#endif
 }
 
 - (void)testUnkownAccessor

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -128,13 +128,13 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 
 @plm_dynamic(emptyObject, @"empty", EmptyObjectTransformer())
 
-@plm_nullable_dynamic(nilString)
-@plm_nullable_dynamic(nilString2, @"nil_string2")
+@plm_dynamic_nullable(nilString)
+@plm_dynamic_nullable(nilString2, @"nil_string2")
 
 @plm_dynamic(nonnullString, @"nonnull_string")
 @plm_dynamic(nonnullInt)
 @plm_dynamic(nonnullNumber)
-@plm_nullable_dynamic(nilNumber)
+@plm_dynamic_nullable(nilNumber)
 
 @end
 


### PR DESCRIPTION
### 问题
 OC 中 propery 声明为 nonnull 而 json 返回为空导致 property 实际为 nil 时，转换到 swift 会引起崩溃

### 目标
api 返回错误数据（nullability 和客户端声明不一致），客户端也不会 crash

### 思路
由于 nullability 声明并不属于 property attribute ， [Property Type String](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtPropertyIntrospection.html#//apple_ref/doc/uid/TP40008048-CH101-SW1)  中没有对应 Code，所以从 [ext_propertyAttributes](https://github.com/jspahrsummers/libextobjc/blob/master/extobjc/EXTRuntimeExtensions.h#L165) 中无法得知 nullability 声明情况，所以只能通过 “外部显示方法” 告知 polymorph。

- 为避免 crash，默认情况 getter 不会返回 nil；
- 如果明确需要使用 property 的 nullable 特性（使用了 if (xx.property != nil) 这种判断），则使用 `@plm_nullable_dynamic` 和 `@plm_nullable_dynamic_keypath` 宏。

### 影响
对于代码中使用了 if (xx.property != nil) 这种判断的属性，需要改为使用 `@plm_nullable_dynamic` 或 `@plm_nullable_dynamic_keypath` 宏