### PR TITLE
delete plm_dynamic_nullable and make plm_dynamic support return nil

### DIFF
--- a/Polymorph/Polymorph.h
+++ b/Polymorph/Polymorph.h
@@ -82,16 +82,13 @@
  *      @plm_dynamic(date, GMTDateTransformerName)
  *
  *  Note:
- *  1. Only plm_dynamic_nullable(...) and plm_dynamic_nullable_keypath(...) may return nil, the others will always
- *     return a nonnull value;
+ *  1. plm_dynamic(...) and plm_dynamic_keypath(...) may return nil;
  *  2. plm_dynamic_nonnull(...) and plm_dynamic_nonnull_keypath(...) need to set an object value at the last argument as
        the default value when it is nil;
- *  3. plm_dynamic(...), plm_dynamic_keypath(...) and plm_dynamic_multi(...) will return a default value when the object is nil;
- *  4. It is recommended to use plm_dynamic_nullable_xxx for `nullable` property and plm_dynamic_nonnull_xxx for `nonnull` property.
+ *  3. It is recommended to use plm_dynamic_nonnull_xxx for `nonnull` property so it will provide a default value to avoid
+ *     crashes when convert to `swift` non-optional properties.
  */
-#define plm_dynamic(...)  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), {_plm_dynamic_attr(__VA_ARGS__);})
-
-#define plm_dynamic_nullable(...) \
+#define plm_dynamic(...)  \
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
   NSDictionary *attrs = (NSDictionary *)_plm_dynamic_attr(__VA_ARGS__); \
   if (!attrs) { \
@@ -124,15 +121,8 @@
   _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
     NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
     attrs[_PolymorphAttributeKeypath] = @YES; \
+    attrs[_PolymorphAttributeNullable] = @YES; \
     attrs; \
-  })
-
-#define plm_dynamic_nullable_keypath(...) \
-  _plm_dynamic_impl(metamacro_at(0, __VA_ARGS__), { \
-  NSMutableDictionary *attrs = [_plm_dynamic_attr(__VA_ARGS__) mutableCopy]; \
-  attrs[_PolymorphAttributeKeypath] = @YES; \
-  attrs[_PolymorphAttributeNullable] = @YES; \
-  attrs; \
   })
 
 #define plm_dynamic_nonnull_keypath(...) \
@@ -190,7 +180,6 @@
 #define _PolymorphAttributeDefaultValue  @"dv"
 
 #define _plm_dynamic_attr(...) metamacro_concat(_plm_dynamic_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
-#define _plm_dynamic_nonnull_attr(...) metamacro_concat(_plm_dynamic_nonnull_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
 
 #define _plm_dynamic_attr1(...) nil
 #define _plm_dynamic_attr2(...) @{ \
@@ -207,6 +196,8 @@
   }
 
 #pragma mark - plm_dynamic_nonnull()
+
+#define _plm_dynamic_nonnull_attr(...) metamacro_concat(_plm_dynamic_nonnull_attr, metamacro_argcount(__VA_ARGS__))(__VA_ARGS__)
 
 #define _plm_dynamic_nonnull_attr2(...) @{ \
   _PolymorphAttributeDefaultValue: metamacro_at(1, __VA_ARGS__) \

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -135,15 +135,15 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 
 @plm_dynamic(normalNumbler)
 @plm_dynamic_nonnull(nonnullNumber, @"nonnull_number", [NSNumber numberWithInteger:20])
-@plm_dynamic_nullable(nilNumber, @"nil_number")
+@plm_dynamic(nilNumber, @"nil_number")
 @plm_dynamic_nonnull_keypath(keypathNonnullNumber, @"xxx", [NSNumber numberWithInteger:20])
-@plm_dynamic_nullable_keypath(keypathNilNumber, @"xxx")
+@plm_dynamic_keypath(keypathNilNumber, @"xxx")
 
 @plm_dynamic(normalString)
 @plm_dynamic_nonnull(nonnullString, @"default_nonnull_string")
-@plm_dynamic_nullable(nilString)
+@plm_dynamic(nilString)
 @plm_dynamic_nonnull_keypath(keypathNonnullString, @"yyy", @"keypath_nonnull_string")
-@plm_dynamic_nullable_keypath(keypathNilString, @"yyy")
+@plm_dynamic_keypath(keypathNilString, @"yyy")
 
 @end
 
@@ -183,13 +183,13 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 - (void)testNullability
 {
   _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{}];
-  XCTAssertNotNil(object.normalNumbler);
+  XCTAssertNil(object.normalNumbler);
   XCTAssertEqual(object.nonnullNumber, [NSNumber numberWithInteger:20]);
   XCTAssertNil(object.nilNumber);
   XCTAssertEqual(object.keypathNonnullNumber, [NSNumber numberWithInteger:20]);
   XCTAssertNil(object.keypathNilNumber);
 
-  XCTAssertNotNil(object.normalString);
+  XCTAssertNil(object.normalString);
   XCTAssertEqual(object.nonnullString, @"default_nonnull_string");
   XCTAssertNil(object.nilString);
   XCTAssertEqual(object.keypathNonnullString, @"keypath_nonnull_string");
@@ -310,7 +310,7 @@ metamacro_foreach(dynamic_type_iter,, PRIMITIVE_TYPES)
 {
   _TypesObject *object = [[_TypesObject alloc] initWithDictionary:@{@"is_voted": [NSNull null], @"url": [NSNull null]}];
   XCTAssertEqual(object.isVoted, NO);
-  XCTAssertNotNil(object.url);
+  XCTAssertNil(object.url);
 }
 
 - (void)testKeypath


### PR DESCRIPTION
调整了下，去掉了 plm_dynamic_nullable_xxx，默认的 plm_dynamic_xxx 就是 nullable 的。这样原有的**判空逻辑**不会受影响。只需要检查声明为 nonnull 的属性，将其改为使用 plm_dynamic_nonull_xxx